### PR TITLE
fix: 修改包名

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "chinese-lang",
+    "name": "tu6ge/voyager-chinese-lang",
     "description": "voyager chinese-lang hook",
     "type": "library",
     "license": "MIT",


### PR DESCRIPTION
安装时候会出现下面这个警告：

```txt
Deprecation warning: require.chinese-lang is invalid, it should have a vendor name, a forward slash, and a package name. The vendor and package name can be words separated by -, . or _. The complete name should match "[a-z0-9]([_.-]?[a-z0-9]+)*/[a-z0-9]([_.-]?[a-z0-9]+)*". Make sure you fix this as Composer 2.0 will error.
```
冒昧的用了仓库的名字作为包的名字。调整后，警告将不再出现。